### PR TITLE
fix variable name and import errors; use cpu when no nvidia gpu.

### DIFF
--- a/experiments/MNIST/YOPO-5-10/dataset.py
+++ b/experiments/MNIST/YOPO-5-10/dataset.py
@@ -8,7 +8,7 @@ def create_train_dataset(batch_size = 128, root = '../data'):
      transforms.ToTensor(),
     ])
     trainset = torchvision.datasets.MNIST(root=root, train=True, download=True, transform=transform_train)
-    trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size, shuffle=True, num_workers=2)
+    trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size, shuffle=True, num_workers=2 if torch.cuda.is_available() else 0)
 
     return trainloader
 def create_test_dataset(batch_size = 128, root = '../data'):
@@ -16,7 +16,7 @@ def create_test_dataset(batch_size = 128, root = '../data'):
      transforms.ToTensor(),
     ])
     testset = torchvision.datasets.MNIST(root=root, train=False, download=True, transform=transform_test)
-    testloader = torch.utils.data.DataLoader(testset, batch_size=batch_size, shuffle=False, num_workers=2)
+    testloader = torch.utils.data.DataLoader(testset, batch_size=batch_size, shuffle=False, num_workers=2 if torch.cuda.is_available() else 0)
     return testloader
 
 

--- a/experiments/MNIST/YOPO-5-10/eval.py
+++ b/experiments/MNIST/YOPO-5-10/eval.py
@@ -18,7 +18,7 @@ parser.add_argument('-d', type=int, default=0, help='Which gpu to use')
 args = parser.parse_args()
 
 
-DEVICE = torch.device('cuda:{}'.format(args.d))
+DEVICE = torch.device('cuda:{}'.format(args.d)) if torch.cuda.is_available() else torch.device('cpu')
 torch.backends.cudnn.benchmark = True
 
 net = create_network()

--- a/experiments/MNIST/YOPO-5-10/train.py
+++ b/experiments/MNIST/YOPO-5-10/train.py
@@ -18,7 +18,7 @@ import torch.optim as optim
 import os
 import time
 
-DEVICE = torch.device('cuda:{}'.format(args.d))
+DEVICE = torch.device('cuda:{}'.format(args.d)) if torch.cuda.is_available() else torch.device('cpu')
 torch.backends.cudnn.benchmark = True
 
 # writer = SummaryWriter(log_dir=config.log_dir)

--- a/lib/attack/pgd.py
+++ b/lib/attack/pgd.py
@@ -58,7 +58,7 @@ class IPGD(AttackBase):
         pred = net(adv_inp)
         if target is not None:
             targets = torch.sum(pred[:, target])
-            grad_sign = torch.autograd.grad(targets, adv_in, only_inputs=True, retain_graph = False)[0].sign()
+            grad_sign = torch.autograd.grad(targets, adv_inp, only_inputs=True, retain_graph = False)[0].sign()
 
         else:
             loss = self.criterion(pred, label)

--- a/lib/base_model/cifar_resnet18.py
+++ b/lib/base_model/cifar_resnet18.py
@@ -116,7 +116,7 @@ def ResNet152():
 
 
 def test():
-    net = ResNet18()
+    net = cifar_resnet18()
     y = net(torch.randn(1,3,32,32))
     print(y.size())
 

--- a/lib/base_model/small_cnn.py
+++ b/lib/base_model/small_cnn.py
@@ -8,6 +8,7 @@ this code is from https://github.com/yaodongyu/TRADES/blob/master/models/small_c
 }
 '''
 from collections import OrderedDict
+import torch
 import torch.nn as nn
 
 

--- a/lib/utils/misc.py
+++ b/lib/utils/misc.py
@@ -1,7 +1,9 @@
 import math
 import os
+import sys
 from typing import Tuple, List, Dict
 import torch
+import json
 
 def torch_accuracy(output, target, topk=(1,)) -> List[torch.Tensor]:
     '''


### PR DESCRIPTION
fix: variable name and import errors.

If `num_workers=2` in `torch.utils.data.DataLoader()`, an error will occur without nvidia gpu. So I let `num_workers=2 if torch.cuda.is_available() else 0` to run use cpu when no nvidia gpu.
